### PR TITLE
Load default character set with LoadFontEx

### DIFF
--- a/Sources/Raylib/raylib_h_text.swift
+++ b/Sources/Raylib/raylib_h_text.swift
@@ -29,7 +29,7 @@ public extension Raylib {
     
     /// Load font from file with extended parameters
     @inlinable
-    static func loadFontEx(_ fileName: String, _ fontSize: Int32, _ fontChars: [Character]?) -> Font {
+    static func loadFontEx(_ fileName: String, _ fontSize: Int32, _ fontChars: [Character]? = nil) -> Font {
         return fileName.withCString { cString in
             if fontChars == nil {
                 return _RaylibC.LoadFontEx(cString, fontSize, nil, 0)

--- a/Sources/Raylib/raylib_h_text.swift
+++ b/Sources/Raylib/raylib_h_text.swift
@@ -29,11 +29,15 @@ public extension Raylib {
     
     /// Load font from file with extended parameters
     @inlinable
-    static func loadFontEx(_ fileName: String, _ fontSize: Int32, _ fontChars: [Character]) -> Font {
+    static func loadFontEx(_ fileName: String, _ fontSize: Int32, _ fontChars: [Character]?) -> Font {
         return fileName.withCString { cString in
-            var chars: [Int32] = fontChars.compactMap({$0.utf8.first}).map({Int32($0)})
-            return chars.withUnsafeMutableBufferPointer { bufferPointer in
-                return _RaylibC.LoadFontEx(cString, fontSize, bufferPointer.baseAddress, Int32(bufferPointer.count))
+            if fontChars == nil {
+                return _RaylibC.LoadFontEx(cString, fontSize, nil, 0)
+            } else {
+                var chars: [Int32] = fontChars!.compactMap({$0.utf8.first}).map({Int32($0)})
+                return chars.withUnsafeMutableBufferPointer { bufferPointer in
+                    return _RaylibC.LoadFontEx(cString, fontSize, bufferPointer.baseAddress, Int32(bufferPointer.count))
+                }
             }
         }
     }


### PR DESCRIPTION
Raylib allows loading of the default character set with `LoadFontEx` by setting `fontChars` to null. 

This fix should allow for the same behavior when using the bindings.